### PR TITLE
(chore) updated gitignore to add swp/tmp files and godot clutter files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,11 @@
 # Godot 4+ specific ignores
 .godot/
+
+# .swp / .tmp files
+*.swp
+*.tmp
+
+# godot-specific files
+.import/
+export_presets.cfg
+


### PR DESCRIPTION
## Task
Updated .gitignore file, this will make it so when a *.swp / *.tmp, .import/, or export_presets.cfg file is committed, it'll not save in git's versioning and not show up in the Github repo.

