### PR TITLE
Fix level1 break error: when health change break because of var_label

### DIFF
--- a/scenes/level1.tscn
+++ b/scenes/level1.tscn
@@ -1,10 +1,11 @@
-[gd_scene load_steps=17 format=3 uid="uid://cfu6qp58epi4y"]
+[gd_scene load_steps=18 format=3 uid="uid://cfu6qp58epi4y"]
 
 [ext_resource type="Texture2D" uid="uid://be6smq1lv47ux" path="res://assets/art/placeholder_tilemap.png" id="1_unyct"]
 [ext_resource type="PackedScene" uid="uid://ch2lhx4dpevpr" path="res://scenes/main_character.tscn" id="2_ff2mj"]
 [ext_resource type="PackedScene" uid="uid://sjigmrytna27" path="res://scenes/enemy.tscn" id="3_ker7w"]
 [ext_resource type="Script" path="res://scenes/game_manager.gd" id="4_3cxwl"]
 [ext_resource type="Script" path="res://scenes/death_area.gd" id="5_8xsqu"]
+[ext_resource type="Script" path="res://scenes/var_label.gd" id="5_q5mm8"]
 [ext_resource type="PackedScene" path="res://scenes/checkpoint.tscn" id="7_idqrs"]
 [ext_resource type="PackedScene" uid="uid://c25ti6th3m4d1" path="res://scenes/global.tscn" id="7_ytou0"]
 [ext_resource type="PackedScene" uid="uid://vdj4i8x4pxm1" path="res://scenes/coin.tscn" id="9_ag2iv"]
@@ -118,9 +119,11 @@ offset_left = 9.0
 offset_right = -9.0
 grow_horizontal = 2
 grow_vertical = 2
-text = "Health: 100"
+text = "Health: 100 | Coins: 0
+"
 horizontal_alignment = 1
 vertical_alignment = 1
+script = ExtResource("5_q5mm8")
 metadata/_edit_use_anchors_ = true
 
 [node name="Level1Floor_Area" type="Area2D" parent="."]


### PR DESCRIPTION
var_label script not attached, so can't refernce update_label function in game_manager functions. The text was incorrect as well, didn't include coins.