### PR TITLE
Camera adjust on level

### DIFF
--- a/scenes/global.gd
+++ b/scenes/global.gd
@@ -9,5 +9,14 @@ var camera_ceiling = 265
 var camera_x_min = 340
 var camera_x_max = 4600
 
+func adjust_camera(floor, ceiling, x_min, x_max, camera_node):
+	Global.camera_floor = floor
+	Global.camera_ceiling = ceiling
+	Global.camera_x_min = x_min
+	Global.camera_x_max = x_max
+	
+	camera_node.position.x = x_min
+	camera_node.position.y = floor
+	
 func update_position(new_position):
 	spawn_position = new_position

--- a/scenes/global.gd
+++ b/scenes/global.gd
@@ -9,6 +9,11 @@ var camera_ceiling = 265
 var camera_x_min = 340
 var camera_x_max = 4600
 
+#Must be fed max and min values AND the camera node in order
+#to set its initial location
+#IMPORTANT: AT camera zoom (1.2)...
+#IMPORTANT: camera location is 384 pixels offset from x min/max
+#IMPORTANT: camera location is 216 pixels offset from y min/max
 func adjust_camera(floor, ceiling, x_min, x_max, camera_node):
 	Global.camera_floor = floor
 	Global.camera_ceiling = ceiling

--- a/scenes/level1.tscn
+++ b/scenes/level1.tscn
@@ -1,12 +1,13 @@
-[gd_scene load_steps=18 format=3 uid="uid://cfu6qp58epi4y"]
+[gd_scene load_steps=19 format=3 uid="uid://cfu6qp58epi4y"]
 
+[ext_resource type="Script" path="res://scenes/level_1.gd" id="1_10m1u"]
 [ext_resource type="Texture2D" uid="uid://be6smq1lv47ux" path="res://assets/art/placeholder_tilemap.png" id="1_unyct"]
 [ext_resource type="PackedScene" uid="uid://ch2lhx4dpevpr" path="res://scenes/main_character.tscn" id="2_ff2mj"]
 [ext_resource type="PackedScene" uid="uid://sjigmrytna27" path="res://scenes/enemy.tscn" id="3_ker7w"]
 [ext_resource type="Script" path="res://scenes/game_manager.gd" id="4_3cxwl"]
 [ext_resource type="Script" path="res://scenes/death_area.gd" id="5_8xsqu"]
 [ext_resource type="Script" path="res://scenes/var_label.gd" id="5_q5mm8"]
-[ext_resource type="PackedScene" path="res://scenes/checkpoint.tscn" id="7_idqrs"]
+[ext_resource type="PackedScene" uid="uid://daeoooqxrqa3h" path="res://scenes/checkpoint.tscn" id="7_idqrs"]
 [ext_resource type="PackedScene" uid="uid://c25ti6th3m4d1" path="res://scenes/global.tscn" id="7_ytou0"]
 [ext_resource type="PackedScene" uid="uid://vdj4i8x4pxm1" path="res://scenes/coin.tscn" id="9_ag2iv"]
 
@@ -70,6 +71,7 @@ size = Vector2(987, 23)
 size = Vector2(142.25, 20)
 
 [node name="Level1Base" type="Node2D"]
+script = ExtResource("1_10m1u")
 
 [node name="MovingCamera" type="Camera2D" parent="."]
 position = Vector2(340, 420)

--- a/scenes/level_1.gd
+++ b/scenes/level_1.gd
@@ -1,18 +1,9 @@
 extends Node2D
 
-func adjust_camera(floor, ceiling, x_min, x_max):
-	var camera = get_node("MovingCamera")
-	camera.position.y = floor
-	Global.camera_floor = floor
-	Global.camera_ceiling = ceiling
-	
-	camera.position.x = x_min
-	Global.camera_x_min = x_min
-	Global.camera_x_max = x_max
-	
 # Called when the node enters the scene tree for the first time.
 func _ready():
-	adjust_camera(405, 350, 390, 6500)
+	var camera = get_node("MovingCamera")
+	Global.adjust_camera(405, 350, 390, 6500, camera)
 
 	pass # Replace with function body.
 

--- a/scenes/level_1.gd
+++ b/scenes/level_1.gd
@@ -1,0 +1,22 @@
+extends Node2D
+
+func adjust_camera(floor, ceiling, x_min, x_max):
+	var camera = get_node("MovingCamera")
+	camera.position.y = floor
+	Global.camera_floor = floor
+	Global.camera_ceiling = ceiling
+	
+	camera.position.x = x_min
+	Global.camera_x_min = x_min
+	Global.camera_x_max = x_max
+	
+# Called when the node enters the scene tree for the first time.
+func _ready():
+	adjust_camera(405, 350, 390, 6500)
+
+	pass # Replace with function body.
+
+
+# Called every frame. 'delta' is the elapsed time since the previous frame.
+func _process(delta):
+	pass

--- a/scenes/level_1.gd
+++ b/scenes/level_1.gd
@@ -3,7 +3,8 @@ extends Node2D
 # Called when the node enters the scene tree for the first time.
 func _ready():
 	var camera = get_node("MovingCamera")
-	Global.adjust_camera(405, 350, 390, 6500, camera)
+	#Floor, Ceiling, Xmin, Xmax
+	Global.adjust_camera(405, -134, 390, 6116, camera)
 
 	pass # Replace with function body.
 


### PR DESCRIPTION
Now has a function to adjust the camera's bounds when loading into a level. Level 1 now has a _ready() command section that runs previously made function and successfully adjust's camera's bounds. Added comments with the newly made function that specifies how the camera's position at zoom (1.2) is offset from the actual bounds of the camera's field of view.